### PR TITLE
Develop

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/.github export-ignore
+/tests export-ignore

--- a/src/FluentDriver.php
+++ b/src/FluentDriver.php
@@ -14,6 +14,7 @@ class FluentDriver implements MappingDriver
 {
     protected MappingSet $mappingSet;
     protected bool $checkParents = false;
+    protected bool $useLifecycleAutoMethods = true;
 
     public function __construct(MappingFinder $mappingFinder)
     {
@@ -23,6 +24,11 @@ class FluentDriver implements MappingDriver
     public function checkParents(): void
     {
         $this->checkParents = true;
+    }
+
+    public function disableLifecycleAutoMethods(): void
+    {
+        $this->useLifecycleAutoMethods = true;
     }
 
     public function loadMetadataForClass($className, ClassMetadata $metadata): void
@@ -36,6 +42,10 @@ class FluentDriver implements MappingDriver
         $this->assertMappingClassExists($mappingClassName);
         $mapping = new $mappingClassName();
         $this->assertMappingIsInstanceOfMapping($mapping);
+
+        if(method_exists($mapping, 'enableLifecycleAutoMethods')) {
+            $mapping->enableLifecycleAutoMethods($this->useLifecycleAutoMethods);
+        }
 
         return $mapping;
     }

--- a/src/FluentDriver.php
+++ b/src/FluentDriver.php
@@ -28,7 +28,7 @@ class FluentDriver implements MappingDriver
 
     public function disableLifecycleAutoMethods(): void
     {
-        $this->useLifecycleAutoMethods = true;
+        $this->useLifecycleAutoMethods = false;
     }
 
     public function loadMetadataForClass($className, ClassMetadata $metadata): void

--- a/src/FluentDriver.php
+++ b/src/FluentDriver.php
@@ -13,7 +13,7 @@ use yjiotpukc\MongoODMFluent\MappingSet\MappingSet;
 class FluentDriver implements MappingDriver
 {
     protected MappingSet $mappingSet;
-    protected bool $useMappingInheritance = false;
+    protected bool $useMappingInheritance = true;
     protected bool $useLifecycleAutoMethods = true;
 
     public function __construct(MappingFinder $mappingFinder)
@@ -21,9 +21,9 @@ class FluentDriver implements MappingDriver
         $this->mappingSet = $mappingFinder->makeMappingSet();
     }
 
-    public function enableMappingInheritance(): void
+    public function disableMappingInheritance(): void
     {
-        $this->useMappingInheritance = true;
+        $this->useMappingInheritance = false;
     }
 
     public function disableLifecycleAutoMethods(): void
@@ -57,9 +57,10 @@ class FluentDriver implements MappingDriver
         }
 
         if ($this->useMappingInheritance) {
-            while ($entityClassName = get_parent_class($entityClassName)) {
-                if ($this->mappingSet->exists($entityClassName)) {
-                    return $this->mappingSet->find($entityClassName);
+            $parentEntityClassName = $entityClassName;
+            while ($parentEntityClassName = get_parent_class($parentEntityClassName)) {
+                if ($this->mappingSet->exists($parentEntityClassName)) {
+                    return $this->mappingSet->find($parentEntityClassName);
                 }
             }
         }

--- a/src/FluentDriver.php
+++ b/src/FluentDriver.php
@@ -13,7 +13,7 @@ use yjiotpukc\MongoODMFluent\MappingSet\MappingSet;
 class FluentDriver implements MappingDriver
 {
     protected MappingSet $mappingSet;
-    protected bool $checkParents = false;
+    protected bool $useMappingInheritance = false;
     protected bool $useLifecycleAutoMethods = true;
 
     public function __construct(MappingFinder $mappingFinder)
@@ -21,9 +21,9 @@ class FluentDriver implements MappingDriver
         $this->mappingSet = $mappingFinder->makeMappingSet();
     }
 
-    public function checkParents(): void
+    public function enableMappingInheritance(): void
     {
-        $this->checkParents = true;
+        $this->useMappingInheritance = true;
     }
 
     public function disableLifecycleAutoMethods(): void
@@ -56,7 +56,7 @@ class FluentDriver implements MappingDriver
             return $this->mappingSet->find($entityClassName);
         }
 
-        if ($this->checkParents) {
+        if ($this->useMappingInheritance) {
             while ($entityClassName = get_parent_class($entityClassName)) {
                 if ($this->mappingSet->exists($entityClassName)) {
                     return $this->mappingSet->find($entityClassName);

--- a/src/Mapping/Traits/DocumentMappingTrait.php
+++ b/src/Mapping/Traits/DocumentMappingTrait.php
@@ -10,10 +10,13 @@ use yjiotpukc\MongoODMFluent\Builder\Document\DocumentBuilder;
 
 trait DocumentMappingTrait
 {
+    use LifecycleAutoMethodsTrait;
+
     public function load(ClassMetadata $metadata): void
     {
         $builder = new DocumentBuilder();
         $this->map($builder);
+        $this->addLifecycleAutoMethods($builder);
         $builder->build($metadata);
     }
 

--- a/src/Mapping/Traits/EmbeddedDocumentMappingTrait.php
+++ b/src/Mapping/Traits/EmbeddedDocumentMappingTrait.php
@@ -10,11 +10,14 @@ use yjiotpukc\MongoODMFluent\Builder\EmbeddedDocument;
 
 trait EmbeddedDocumentMappingTrait
 {
+    use LifecycleAutoMethodsTrait;
+
     public function load(ClassMetadata $metadata): void
     {
         $builder = new DocumentBuilder();
         $builder->embeddedDocument();
         $this->map($builder);
+        $this->addLifecycleAutoMethods($builder);
         $builder->build($metadata);
     }
 

--- a/src/Mapping/Traits/LifecycleAutoMethodsTrait.php
+++ b/src/Mapping/Traits/LifecycleAutoMethodsTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yjiotpukc\MongoODMFluent\Mapping\Traits;
+
+use yjiotpukc\MongoODMFluent\Builder\Document\DocumentBuilder;
+
+trait LifecycleAutoMethodsTrait
+{
+    protected bool $useLifecycleAutoMethods;
+
+    public function enableLifecycleAutoMethods(bool $value): void
+    {
+        $this->useLifecycleAutoMethods = $value;
+    }
+
+    public function addLifecycleAutoMethods(DocumentBuilder $builder): void
+    {
+        if (!$this->useLifecycleAutoMethods) {
+            return;
+        }
+
+        $lifecycleMethods = [
+            'preRemove',
+            'postRemove',
+            'prePersist',
+            'postPersist',
+            'preUpdate',
+            'postUpdate',
+            'preLoad',
+            'postLoad',
+            'loadClassMetadata',
+            'onClassMetadataNotFound',
+            'preFlush',
+            'postFlush',
+            'onFlush',
+            'onClear',
+            'documentNotFound',
+            'postCollectionLoad',
+        ];
+
+        foreach ($lifecycleMethods as $lifecycleMethod) {
+            if (method_exists($this, $lifecycleMethod)) {
+                $builder->lifecycle()->{$lifecycleMethod}($lifecycleMethod);
+            }
+        }
+    }
+}

--- a/src/Mapping/Traits/MappedSuperclassMappingTrait.php
+++ b/src/Mapping/Traits/MappedSuperclassMappingTrait.php
@@ -10,11 +10,14 @@ use yjiotpukc\MongoODMFluent\Builder\Document\DocumentBuilder;
 
 trait MappedSuperclassMappingTrait
 {
+    use LifecycleAutoMethodsTrait;
+
     public function load(ClassMetadata $metadata): void
     {
         $builder = new DocumentBuilder();
         $builder->mappedSuperclass();
         $this->map($builder);
+        $this->addLifecycleAutoMethods($builder);
         $builder->build($metadata);
     }
 

--- a/src/Mapping/Traits/QueryResultDocumentMappingTrait.php
+++ b/src/Mapping/Traits/QueryResultDocumentMappingTrait.php
@@ -10,11 +10,14 @@ use yjiotpukc\MongoODMFluent\Builder\QueryResultDocument;
 
 trait QueryResultDocumentMappingTrait
 {
+    use LifecycleAutoMethodsTrait;
+
     public function load(ClassMetadata $metadata): void
     {
         $builder = new DocumentBuilder();
         $builder->queryResultDocument();
         $this->map($builder);
+        $this->addLifecycleAutoMethods($builder);
         $builder->build($metadata);
     }
 

--- a/src/Mapping/Traits/ViewMappingTrait.php
+++ b/src/Mapping/Traits/ViewMappingTrait.php
@@ -10,10 +10,13 @@ use yjiotpukc\MongoODMFluent\Builder\View;
 
 trait ViewMappingTrait
 {
+    use LifecycleAutoMethodsTrait;
+
     public function load(ClassMetadata $metadata): void
     {
         $builder = new DocumentBuilder();
         $this->map($builder);
+        $this->addLifecycleAutoMethods($builder);
         $builder->build($metadata);
     }
 

--- a/src/MappingFinder/SelfMappingFinder.php
+++ b/src/MappingFinder/SelfMappingFinder.php
@@ -11,12 +11,10 @@ use yjiotpukc\MongoODMFluent\Util\ClassScanner;
 
 class SelfMappingFinder implements MappingFinder
 {
-    protected string $mappingClassPattern;
     protected ClassScanner $classScanner;
 
-    public function __construct(string $mappingClassPattern, string $mappingDirectory)
+    public function __construct(string $mappingDirectory)
     {
-        $this->mappingClassPattern = $mappingClassPattern;
         $this->classScanner = new ClassScanner($mappingDirectory);
     }
 

--- a/tests/Integration/DescendantMappingTest.php
+++ b/tests/Integration/DescendantMappingTest.php
@@ -88,7 +88,7 @@ class DescendantMappingTest extends TestCase
         );
         $driver = new FluentDriver($mappingFinder);
         if ($checkParents) {
-            $driver->checkParents();
+            $driver->enableMappingInheritance();
         }
         $config = new Configuration();
         $config->setMetadataDriverImpl($driver);

--- a/tests/Integration/DescendantMappingTest.php
+++ b/tests/Integration/DescendantMappingTest.php
@@ -87,8 +87,8 @@ class DescendantMappingTest extends TestCase
             __DIR__ . '/Resources/Mappings/'
         );
         $driver = new FluentDriver($mappingFinder);
-        if ($checkParents) {
-            $driver->enableMappingInheritance();
+        if (!$checkParents) {
+            $driver->disableMappingInheritance();
         }
         $config = new Configuration();
         $config->setMetadataDriverImpl($driver);

--- a/tests/Integration/LifecycleAutoMethodsTest.php
+++ b/tests/Integration/LifecycleAutoMethodsTest.php
@@ -19,7 +19,7 @@ class LifecycleAutoMethodsTest extends TestCase
 
     public function testLifecycleAutoMethods(): void
     {
-        $documentManager = $this->createDocumentManager();
+        $documentManager = $this->createDocumentManager(true);
         $metadata = $documentManager->getClassMetadata(LifecycleAutoMethodsMapping::class);
 
         $this->assertMappingIsCorrect($metadata);
@@ -42,11 +42,13 @@ class LifecycleAutoMethodsTest extends TestCase
         self::assertEquals($expectedMetadata, $metadata);
     }
 
-    protected function createDocumentManager(): DocumentManager
+    protected function createDocumentManager(bool $useLifecycleAutoMethods): DocumentManager
     {
         $mappingFinder = new SelfMappingFinder(__DIR__ . '/Resources/Mappings/');
         $driver = new FluentDriver($mappingFinder);
-        $driver->disableLifecycleAutoMethods();
+        if (!$useLifecycleAutoMethods) {
+            $driver->disableLifecycleAutoMethods();
+        }
         $config = new Configuration();
         $config->setMetadataDriverImpl($driver);
         $config->setHydratorDir(__DIR__ . '/Resources/Hydrators/');

--- a/tests/Integration/LifecycleAutoMethodsTest.php
+++ b/tests/Integration/LifecycleAutoMethodsTest.php
@@ -22,10 +22,18 @@ class LifecycleAutoMethodsTest extends TestCase
         $documentManager = $this->createDocumentManager(true);
         $metadata = $documentManager->getClassMetadata(LifecycleAutoMethodsMapping::class);
 
-        $this->assertMappingIsCorrect($metadata);
+        $this->assertMappingIsCorrect($metadata, true);
     }
 
-    protected function assertMappingIsCorrect(ClassMetadata $metadata): void
+    public function testDisabledLifecycleAutoMethods(): void
+    {
+        $documentManager = $this->createDocumentManager(false);
+        $metadata = $documentManager->getClassMetadata(LifecycleAutoMethodsMapping::class);
+
+        $this->assertMappingIsCorrect($metadata, false);
+    }
+
+    protected function assertMappingIsCorrect(ClassMetadata $metadata, bool $useLifecycleAutoMethods): void
     {
         $expectedMetadata = new ClassMetadata(LifecycleAutoMethodsMapping::class);
         $expectedMetadata->db = 'dbName';
@@ -37,7 +45,10 @@ class LifecycleAutoMethodsTest extends TestCase
             'notSaved' => false,
         ]);
         $expectedMetadata->setIdGenerator(new AutoGenerator());
-        $expectedMetadata->addLifecycleCallback('preLoad', 'preLoad');
+
+        if ($useLifecycleAutoMethods) {
+            $expectedMetadata->addLifecycleCallback('preLoad', 'preLoad');
+        }
 
         self::assertEquals($expectedMetadata, $metadata);
     }

--- a/tests/Integration/LifecycleAutoMethodsTest.php
+++ b/tests/Integration/LifecycleAutoMethodsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yjiotpukc\MongoODMFluent\Tests\Integration;
+
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Id\AutoGenerator;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
+use yjiotpukc\MongoODMFluent\FluentDriver;
+use yjiotpukc\MongoODMFluent\MappingFinder\SelfMappingFinder;
+use yjiotpukc\MongoODMFluent\Tests\Integration\Resources\Mappings\LifecycleAutoMethodsMapping;
+
+class LifecycleAutoMethodsTest extends TestCase
+{
+    protected static DocumentManager $documentManager;
+
+    public function testLifecycleAutoMethods(): void
+    {
+        $documentManager = $this->createDocumentManager();
+        $metadata = $documentManager->getClassMetadata(LifecycleAutoMethodsMapping::class);
+
+        $this->assertMappingIsCorrect($metadata);
+    }
+
+    protected function assertMappingIsCorrect(ClassMetadata $metadata): void
+    {
+        $expectedMetadata = new ClassMetadata(LifecycleAutoMethodsMapping::class);
+        $expectedMetadata->db = 'dbName';
+        $expectedMetadata->collection = 'simple';
+        $expectedMetadata->mapField([
+            'id' => true,
+            'fieldName' => 'id',
+            'strategy' => 'auto',
+            'notSaved' => false,
+        ]);
+        $expectedMetadata->setIdGenerator(new AutoGenerator());
+        $expectedMetadata->addLifecycleCallback('preLoad', 'preLoad');
+
+        self::assertEquals($expectedMetadata, $metadata);
+    }
+
+    protected function createDocumentManager(): DocumentManager
+    {
+        $mappingFinder = new SelfMappingFinder(__DIR__ . '/Resources/Mappings/');
+        $driver = new FluentDriver($mappingFinder);
+        $driver->disableLifecycleAutoMethods();
+        $config = new Configuration();
+        $config->setMetadataDriverImpl($driver);
+        $config->setHydratorDir(__DIR__ . '/Resources/Hydrators/');
+        $config->setHydratorNamespace('yjiotpukc\MongoODMFluent\Tests\Integration\Resources\Hydrators');
+
+        return DocumentManager::create(null, $config);
+    }
+}

--- a/tests/Integration/Resources/Mappings/LifecycleAutoMethodsMapping.php
+++ b/tests/Integration/Resources/Mappings/LifecycleAutoMethodsMapping.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yjiotpukc\MongoODMFluent\Tests\Integration\Resources\Mappings;
+
+use Doctrine\ODM\MongoDB\Event\PreLoadEventArgs;
+use yjiotpukc\MongoODMFluent\Builder\Document;
+use yjiotpukc\MongoODMFluent\Mapping\Mapping;
+use yjiotpukc\MongoODMFluent\Mapping\Traits\DocumentMappingTrait;
+
+class LifecycleAutoMethodsMapping implements Mapping
+{
+    use DocumentMappingTrait;
+
+    protected string $id;
+    protected string $name;
+
+    public function map(Document $builder): void
+    {
+        $builder->db('dbName');
+        $builder->collection('simple');
+        $builder->id();
+    }
+
+    public function preLoad(PreLoadEventArgs $eventArgs): void
+    {
+        $data = $eventArgs->getData();
+        $this->name = $data['first_name'];
+    }
+}

--- a/tests/Unit/MappingFinder/SelfMappingFinderTest.php
+++ b/tests/Unit/MappingFinder/SelfMappingFinderTest.php
@@ -21,9 +21,7 @@ class SelfMappingFinderTest extends TestCase
 
     protected function createMappingSet(): MappingSet
     {
-        $finder = new SelfMappingFinder('yjiotpukc\\MongoODMFluent\\Tests\\Stubs\\Mappings\\', $this->getDirectoryPath());
-
-        return $finder->makeMappingSet();
+        return (new SelfMappingFinder($this->getDirectoryPath()))->makeMappingSet();
     }
 
     protected function getDirectoryPath(): string


### PR DESCRIPTION
- Removes $mappingClassPattern parameter from SelfMappingFinder constructor
- Adds .gitattributes with export-ignore
- Adds lifecycle auto methods
- Renames checkParents to useMappingInheritance
- Fixes FluentDriver::disableLifecycleAutoMethods
- Fixes LifecycleAutoMethodsTest
- Changes default value of useMappingInheritance to true
- Adds testDisabledLifecycleAutoMethods